### PR TITLE
#ISSUE-4 Set Telegram as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ the previous sha256 hash with the current one.
 5. Insert another comma `,`. Here the script will insert the last date
    it has checked the webpage. This is for you, little human!
 
-6. With Telegram ask the `@BotFather` bot to create a new bot for you.
+6. If you want the output to be sent to Telegram, ask the `@BotFather` bot to create a new bot for you.
    Get your token from the chat with `@BotFather`, add your bot 
    to a group and access `https://api.telegram.org/bot<token>/getUpdates` 
    to get your chat id.
@@ -32,9 +32,15 @@ the previous sha256 hash with the current one.
 Open a terminal window (or powershell in Windows) in the repository folder
 (maybe you have to `cd` to your directory) and type:
 ```shell script
-python main.py your_telegram_token your_chat_id
+python main.py
 ```
-remember to replace `your_telegram_token` and `your_chat_id`!
+
+If you want to receive the results to Telegram, 
+run 
+```shell script
+python main.py --token <your_telegram_token> --chat-id <your_chat_id>
+```
+and replace `<your_telegram_token>` and `<your_chat_id>` with the ones from point 6.
 
 ## Caveat
 Some websites use JavaScript to create the webpage using your browser.

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ import hashlib
 import requests
 import argparse
 import datetime
+import typing
 
 import telegram
 from bs4 import BeautifulSoup
@@ -20,6 +21,46 @@ import pandas as pd
 
 # TODO: parallelize with ThreadPoolExecutor
 #   see https://realpython.com/python-concurrency/#threading-version
+
+
+def get_output_channel() -> typing.Optional[typing.Tuple[telegram.Bot, str]]:
+    """
+    Parse the optional CLI arguments, which consist of the Telegram
+    token and the chat-id.
+
+    If no argument is passed, print the output to the command line.
+
+    :return: ``None`` if no CLI argument is passed is, otherwise
+        the instantiated Telegram bot and the chat-id.
+    """
+
+    # first parse the Telegram bot token and the chat id
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-t', '--token',
+        required=False, help='Telegram bot token'
+    )
+    parser.add_argument(
+        '-c', '--chat-id', required=False,
+        help='ID of the chat opened with your bot'
+    )
+    args = parser.parse_args()
+
+    telegram_token = args.token
+    telegram_chat_id = args.chat_id
+
+    if telegram_token is None or telegram_chat_id is None:
+        print(
+            '⚠ Telegram token and chat-id not passed through the command line',
+            '➡ I will print the output to this terminal window',
+            sep='\n', end='\n------------\n'
+        )
+        return
+
+    # instantiate the bot
+    telegram_bot = telegram.Bot(token=telegram_token)
+
+    return telegram_bot, telegram_chat_id
 
 
 def open_website(web_site: str) -> bytes:
@@ -106,16 +147,9 @@ def write_csv_data(csv_file_path: str, data: dict) -> None:
 
 
 if __name__ == '__main__':
-    # first parse the Telegram bot token and the chat id
-    parser = argparse.ArgumentParser()
-    parser.add_argument('token', help='Telegram bot token')
-    parser.add_argument('chatid', help='ID of the chat opened with your')
-    args = parser.parse_args()
-    token = args.token
-    chat_id = args.chatid
 
-    # instantiate the bot
-    bot = telegram.Bot(token=token)
+    # get the channel (Telegram or terminal) where to send the output
+    output_channel = get_output_channel()
 
     # define the path of the .csv file relatively to this script's folder
     file_path = pathlib.Path(__file__).with_name('websites.csv')
@@ -140,17 +174,25 @@ if __name__ == '__main__':
 
         # compare the previous hash with the new one
         if new_hash != previous_hash:
-            print(f'{website} è cambiato!')
+            print(f'{website} changed!')
             # add the website to the list for the Telegram notification
-            changed_list.append(f'{website} è cambiato!')
+            changed_list.append(f'{website} changed!')
             # update data to be store into the .csv file
             websites_data[website]['hash'] = new_hash
             websites_data[website]['last_change_date'] = \
                 datetime.datetime.today().strftime('%Y-%m-%d')
 
-    # changed websites? Notify me via Telegram
+    # changed websites? Notify me via Telegram or at the terminal
     if len(changed_list) != 0:
-        bot.send_message(chat_id=chat_id, text='\n\n'.join(changed_list))
+        if output_channel is not None:
+            output_channel[0].send_message(
+                chat_id=output_channel[1],
+                text='\n\n'.join(changed_list)
+            )
+        else:
+            print('\n------------')
+            print('⏬ Check results ⏬')
+            print('\n\n'.join(changed_list))
 
-    # store new data in the .csv file
-    write_csv_data(file_path, websites_data)
+        # store new data in the .csv file
+        write_csv_data(file_path, websites_data)

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ def open_website(web_site: str) -> bytes:
     Open a website and return the content as bytes.
 
     :param web_site: url as string.
-    :return: bytes with the HTML content of the webpage.
+    :return: bytes with the HTML content of the web-page.
     """
     with requests.Session() as session:
         with session.get(web_site) as response:
@@ -79,7 +79,7 @@ def open_website(web_site: str) -> bytes:
 def filter_element(content: bytes, element: str) -> bytes:
     """
     Get the desired element (an ``id`` or a ``class`` in the html)
-    or the whole webpage if no element has been selected.
+    or the whole web-page if no element has been selected.
 
     :param content: raw html.
     :param element: name of the ``id`` or the ``class`` in the raw html.
@@ -98,7 +98,8 @@ def filter_element(content: bytes, element: str) -> bytes:
 
 def get_sha256(byte_string: bytes) -> str:
     """
-    Compute the sha256 hash of a bytes string (the HTML content of the webpage).
+    Compute the sha256 hash of a bytes string
+    (which is meant to be the HTML content of the web-page).
 
     :param byte_string: string of which compute the hash.
     :return: a string with the sha256 hash.


### PR DESCRIPTION
Telegram should not be the only way to receive the monitoring results.

If no token nor chat-id are passed when calling `main.py`, the output will be displayed in the terminal.

Fix Issue #4 